### PR TITLE
Fix: Fixed bug in __getattr__ of parameter class.

### DIFF
--- a/brkraw/api/pvobj/parameters.py
+++ b/brkraw/api/pvobj/parameters.py
@@ -169,16 +169,37 @@ class Parameter:
         """
         return self.parameters[key]
     
-    def __getattr__(self, key):
-        """Allows attribute-like access to parameters.
+    def __getattr__(self, key: str):
+        """Provides attribute-like access to the `parameters` dictionary.
+
+        This method is called when an attribute lookup fails. It checks the
+        `parameters` dictionary for the requested key and returns the associated
+        value if found.
+
+        Note:
+            If the key is not found in `parameters`, an `AttributeError` is raised
+            instead of a `KeyError` because `getattr()` is designed to handle
+            `AttributeError` when an attribute is not found.
 
         Args:
-            key (str): The key for the desired parameter.
+            key (str): The key to look up in the `parameters` dictionary.
 
         Returns:
-            The value associated with the key in the parameters dictionary.
+            Any: The value associated with the given key in `parameters`.
+
+        Raises:
+            AttributeError: If the key is not present in `parameters` and cannot
+                            be accessed as an attribute.
         """
-        return self.parameters[key]
+        # Attempt to retrieve the value from the parameters dictionary.
+        if hasattr(self, "parameters") and isinstance(self.parameters, dict):
+            if key in self.parameters:
+                return self.parameters[key]
+
+        raise AttributeError(
+            f"'{type(self).__name__}' object has no attribute '{key}' "
+            f"and the key '{key}' is not present in the `parameters` dictionary."
+        )
     
     def __repr__(self):
         """Provide a string representation of the Parameter object for debugging and logging.


### PR DESCRIPTION
The current __getattr__ implementation of the `Parameter` class can lead to a bug:

Calling `help()` on any Parameter object
```python
....
method = scan_data.pvobj["method"]
help(method)
```
will lead to an error message:
```python
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In[13], line 1
----> 1 help(method)

File [/opt/homebrew/Caskroom/miniforge/base/lib/python3.10/_sitebuiltins.py:103](http://localhost:8888/opt/homebrew/Caskroom/miniforge/base/lib/python3.10/_sitebuiltins.py#line=102), in _Helper.__call__(self, *args, **kwds)
    101 def __call__(self, *args, **kwds):
    102     import pydoc
--> 103     return pydoc.help(*args, **kwds)

File [/opt/homebrew/Caskroom/miniforge/base/lib/python3.10/pydoc.py:2006](http://localhost:8888/opt/homebrew/Caskroom/miniforge/base/lib/python3.10/pydoc.py#line=2005), in Helper.__call__(self, request)
   2004 def __call__(self, request=_GoInteractive):
   2005     if request is not self._GoInteractive:
-> 2006         self.help(request)
   2007     else:
   2008         self.intro()

File [/opt/homebrew/Caskroom/miniforge/base/lib/python3.10/pydoc.py:2065](http://localhost:8888/opt/homebrew/Caskroom/miniforge/base/lib/python3.10/pydoc.py#line=2064), in Helper.help(self, request)
   2063     else: doc(str, 'Help on %s:', output=self._output)
   2064 elif isinstance(request, Helper): self()
-> 2065 else: doc(request, 'Help on %s:', output=self._output)
   2066 self.output.write('\n')

File [/opt/homebrew/Caskroom/miniforge/base/lib/python3.10/pydoc.py:1785](http://localhost:8888/opt/homebrew/Caskroom/miniforge/base/lib/python3.10/pydoc.py#line=1784), in doc(thing, title, forceload, output)
   1783 try:
   1784     if output is None:
-> 1785         pager(render_doc(thing, title, forceload))
   1786     else:
   1787         output.write(render_doc(thing, title, forceload, plaintext))

File [/opt/homebrew/Caskroom/miniforge/base/lib/python3.10/pydoc.py:1758](http://localhost:8888/opt/homebrew/Caskroom/miniforge/base/lib/python3.10/pydoc.py#line=1757), in render_doc(thing, title, forceload, renderer)
   1756 if renderer is None:
   1757     renderer = text
-> 1758 object, name = resolve(thing, forceload)
   1759 desc = describe(object)
   1760 module = inspect.getmodule(object)

File [/opt/homebrew/Caskroom/miniforge/base/lib/python3.10/pydoc.py:1750](http://localhost:8888/opt/homebrew/Caskroom/miniforge/base/lib/python3.10/pydoc.py#line=1749), in resolve(thing, forceload)
   1748     return object, thing
   1749 else:
-> 1750     name = getattr(thing, '__name__', None)
   1751     return thing, name if isinstance(name, str) else None

File [.../brkraw/brkraw/api/pvobj/parameters.py:201](http://localhost:8888/lab/workspaces/~/PhD/tools/python/brkraw/brkraw/api/pvobj/parameters.py#line=200), in Parameter.__getattr__(self, key)
    179 def __getattr__(self, key: str):
    180     """Provides attribute-like access to the `parameters` dictionary.
    181 
    182     This method is called when an attribute lookup fails. It checks the
   (...)
    199                         be accessed as an attribute.
    200     """
--> 201     return self.parameters[key]
    202     # Attempt to retrieve the value from the parameters dictionary.
    203     if hasattr(self, "parameters") and isinstance(self.parameters, dict):

KeyError: '__name__'
```


This has something to do with pydoc calling `getattr(thing, '__name__', None)` on every "`thing`".

Since `thing` is in our case a `Parameter`-class object, the '__name__' is neither in `self.__dict__` nor in `self.parameters` and a `KeyError` is thrown.
The problem is: `getattr(...)` only catches `AttributeError` and the `help()`-function fails.

To account for this, all we have to do is catch a potential `KeyError` and throw an `AttributeError` instead.


@BrkRaw/brkraw
